### PR TITLE
@dsukmanova Сукманова Дарья

### DIFF
--- a/app/src/main/java/ru/yandex/yamblz/ui/views/CustomViewGroup.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/views/CustomViewGroup.java
@@ -1,0 +1,70 @@
+package ru.yandex.yamblz.ui.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Created by dsukmanova on 26.07.16.
+ */
+
+public class CustomViewGroup extends ViewGroup {
+    public CustomViewGroup(Context context) {
+        super(context);
+    }
+
+    public CustomViewGroup(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CustomViewGroup(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = MeasureSpec.getSize(widthMeasureSpec);
+        int height = MeasureSpec.getSize(heightMeasureSpec);
+        int elementsWidth = 0;
+        View matchParentElement = null;
+
+        int count = getChildCount();
+        for (int i = 0; i < count; i++) {
+            final View childView = getChildAt(i);
+            if (childView.getVisibility() == GONE) continue;
+            LayoutParams layoutParams = childView.getLayoutParams();
+            measureChild(childView, widthMeasureSpec, heightMeasureSpec);
+
+            if (layoutParams.width != LayoutParams.MATCH_PARENT) {
+                measureChild(childView, widthMeasureSpec, heightMeasureSpec);
+                elementsWidth += childView.getMeasuredWidth();
+            } else {
+                matchParentElement = childView;
+            }
+        }
+        if (matchParentElement != null) {
+            int mpWidthSpec = MeasureSpec.makeMeasureSpec(Math.max(0, width - elementsWidth), MeasureSpec.EXACTLY);
+            int mpHeightSpec = MeasureSpec.makeMeasureSpec(matchParentElement.getMeasuredHeight(), MeasureSpec.EXACTLY);
+            matchParentElement.measure(mpWidthSpec, mpHeightSpec);
+        }
+        setMeasuredDimension(width, height);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        int count = getChildCount();
+        int elementStart = getPaddingLeft();
+        int elementTop = getPaddingTop();
+        int newElementStart;
+
+        for (int i = 0; i < count; i++) {
+            final View childView = getChildAt(i);
+            if (childView.getVisibility() == GONE) continue;
+            newElementStart = elementStart + childView.getMeasuredWidth();
+            childView.layout(elementStart, elementTop, newElementStart, elementTop + childView.getMeasuredHeight());
+            elementStart = newElementStart;
+        }
+    }
+}

--- a/app/src/main/java/ru/yandex/yamblz/ui/views/CustomViewGroup.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/views/CustomViewGroup.java
@@ -38,7 +38,6 @@ public class CustomViewGroup extends ViewGroup {
             measureChild(childView, widthMeasureSpec, heightMeasureSpec);
 
             if (layoutParams.width != LayoutParams.MATCH_PARENT) {
-                measureChild(childView, widthMeasureSpec, heightMeasureSpec);
                 elementsWidth += childView.getMeasuredWidth();
             } else {
                 matchParentElement = childView;

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent">
 
-    <TextView
+    <ru.yandex.yamblz.ui.views.CustomViewGroup
+        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/content"
-        android:textSize="42sp"
-        android:gravity="center"
-        />
-
-</FrameLayout>
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="wrap_content"
+            android:background="@color/gray"
+            />
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:text="50dp"
+            android:background="@color/black"
+            android:textColor="@color/white"
+            />
+        <TextView
+            android:layout_width="80dp"
+            android:layout_height="wrap_content"
+            android:text="80dp"
+            android:background="@color/gray"
+            />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="match_parent"
+            android:background="@color/black"
+            android:textColor="@color/white"
+            />
+    </ru.yandex.yamblz.ui.views.CustomViewGroup>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,12 +2,12 @@ ext.versions = [
         code                         : 1,
         name                         : '1.0',
 
-        minSdk                       : 16,
+        minSdk                       : 17,
         targetSdk                    : 23,
         compileSdk                   : 23,
         buildTools                   : '23.0.3',
 
-        androidGradlePlugin          : '2.2.0-alpha4',
+        androidGradlePlugin          : '2.2.0-alpha5',
         aptGradlePlugin              : '1.8',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',


### PR DESCRIPTION
![screen_snapshot](https://cloud.githubusercontent.com/assets/17475606/17151762/dd3ea2d0-5385-11e6-97c4-c46fcaf0893f.png)

Примечание: хотела не делать measureChild для view с параметром match-parent в цикле, а сделать отдельно после:
`matchParentElement.measure(mpWidthSpec, heightMeasureSpec);`

В таком случае получала, что этот элемент растягивался на всю высоту. Не смогла понять, почему так происходит, можете пожалуйста пояснить? 
