### PR TITLE
Владимир Каткалов @katkalov

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
     buildToolsVersion versions.buildTools
 
     defaultConfig {
-        applicationId 'ru.yandex.yamblz'
+        applicationId 'ru.yandex.yamblz_customviewgroup'
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode versions.code // Notice that you may want to use BUILD_NUMBER from CI in real project with own CI.

--- a/app/src/main/java/ru/yandex/yamblz/App.java
+++ b/app/src/main/java/ru/yandex/yamblz/App.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import com.facebook.stetho.Stetho;
+
 import ru.yandex.yamblz.developer_settings.DevMetricsProxy;
 import ru.yandex.yamblz.developer_settings.DeveloperSettingsModel;
 import timber.log.Timber;
@@ -31,6 +33,11 @@ public class App extends Application {
             DevMetricsProxy devMetricsProxy = applicationComponent.devMetricsProxy();
             devMetricsProxy.apply();
         }
+        Stetho.initialize(
+                Stetho.newInitializerBuilder(this)
+                        .enableDumpapp(Stetho.defaultDumperPluginsProvider(this))
+                        .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(this))
+                        .build());
     }
 
     @NonNull

--- a/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
@@ -24,10 +24,12 @@ public class CustomLayout extends ViewGroup {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int horizontalPadding = getPaddingLeft() + getPaddingRight();
+        int verticalPadding = getPaddingTop() + getPaddingBottom();
         int totalWidth = 0;
-        int layoutWidth = MeasureSpec.getSize(widthMeasureSpec);
+        int layoutWidth = MeasureSpec.getSize(widthMeasureSpec) - horizontalPadding;
         //Высота лейаута по высоте максимального элемента
-        int maxHeight = MeasureSpec.getSize(heightMeasureSpec);
+        int maxHeight = MeasureSpec.getSize(heightMeasureSpec) - verticalPadding;
         int changedHeightMeasureSpec = heightMeasureSpec;
 
         //Родитель может вызвать onMeasure не единожды
@@ -56,7 +58,6 @@ public class CustomLayout extends ViewGroup {
                     }
             }
         }
-
         //Если осталось место или оно не ограничено, почему бы не показать matchParent
         if ((totalWidth < layoutWidth) || widthMeasureSpec == MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)) {
             //В случае, если не знаем ширина родителя не остановленна,используем  вдвое увеличенную ширину не match_parent элементов
@@ -65,7 +66,15 @@ public class CustomLayout extends ViewGroup {
             int mpChildWidth = (layoutWidth - totalWidth) / mMatchParentChildren.size();
             int childWidthMeasureSpec = MeasureSpec.makeMeasureSpec(mpChildWidth, MeasureSpec.EXACTLY);
             for (int i = 0; i < mMatchParentChildren.size(); i++) {
-                measureChild(mMatchParentChildren.get(i), childWidthMeasureSpec, changedHeightMeasureSpec);
+                int childHeightMeasureSpec = getChildMeasureSpec(
+                        heightMeasureSpec,
+                        verticalPadding,
+                        mMatchParentChildren.get(i).getLayoutParams().height
+                );
+                mMatchParentChildren.get(i).measure(
+                        childWidthMeasureSpec,
+                        childHeightMeasureSpec
+                );
                 totalWidth += mMatchParentChildren.get(i).getMeasuredWidth();
                 int measuredHeight = mMatchParentChildren.get(i).getMeasuredHeight();
                 if (maxHeight < measuredHeight) {
@@ -74,7 +83,7 @@ public class CustomLayout extends ViewGroup {
                 }
             }
         }
-        super.onMeasure(MeasureSpec.makeMeasureSpec(layoutWidth, MeasureSpec.EXACTLY), changedHeightMeasureSpec);
+        super.onMeasure(MeasureSpec.makeMeasureSpec(layoutWidth + horizontalPadding, MeasureSpec.EXACTLY), changedHeightMeasureSpec);
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
@@ -85,6 +85,9 @@ public class CustomLayout extends ViewGroup {
         int childCount = getChildCount();
         for (int i = 0; i < childCount; ++i) {
             View child = getChildAt(i);
+            if (child.getVisibility() == GONE) {
+                continue;
+            }
             int childWidth = child.getMeasuredWidth();
             int childHeight = child.getMeasuredHeight();
             child.layout(horizontalOffset, verticalOffset, horizontalOffset + childWidth, verticalOffset + childHeight);

--- a/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
@@ -1,0 +1,97 @@
+package ru.yandex.yamblz.ui.layouts;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+
+public class CustomLayout extends ViewGroup {
+    private ArrayList<View> mMatchParentChildren = new ArrayList<>();
+
+    public CustomLayout(Context context) {
+        this(context, null, 0);
+    }
+
+    public CustomLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public CustomLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int totalWidth = 0;
+        int layoutWidth = MeasureSpec.getSize(widthMeasureSpec);
+        //Высота лейаута по высоте максимального элемента
+        int maxHeight = MeasureSpec.getSize(heightMeasureSpec);
+        int changedHeightMeasureSpec = heightMeasureSpec;
+
+        //Родитель может вызвать onMeasure не единожды
+        mMatchParentChildren.clear();
+
+
+        for (int i = 0; i < getChildCount(); ++i) {
+            View child = getChildAt(i);
+
+            if (child == null) {
+                continue;
+            }
+            if (child.getVisibility() == GONE) {
+                continue;
+            }
+
+            switch (child.getLayoutParams().width) {
+                case LayoutParams.MATCH_PARENT:
+                    mMatchParentChildren.add(child);
+                    break;
+                case LayoutParams.WRAP_CONTENT:
+                default:
+                    measureChild(child, widthMeasureSpec, heightMeasureSpec);
+                    totalWidth += child.getMeasuredWidth();
+                    int measuredHeight = child.getMeasuredHeight();
+                    if (maxHeight < measuredHeight) {
+                        maxHeight = measuredHeight;
+                        changedHeightMeasureSpec = MeasureSpec.makeMeasureSpec(maxHeight, MeasureSpec.UNSPECIFIED);
+                    }
+            }
+        }
+
+        //Если осталось место или оно не ограничено, почему бы не показать matchParent
+        if ((totalWidth < layoutWidth) || widthMeasureSpec == MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)) {
+            //В случае, если не знаем ширина родителя не остановленна,используем  вдвое увеличенную ширину не match_parent элементов
+            layoutWidth = layoutWidth != 0 ? layoutWidth : totalWidth * 2;
+            //Остаток разделям между оставшимися детьми
+            int mpChildWidth = (layoutWidth - totalWidth) / mMatchParentChildren.size();
+            int childWidthMeasureSpec = MeasureSpec.makeMeasureSpec(mpChildWidth, MeasureSpec.EXACTLY);
+            for (int i = 0; i < mMatchParentChildren.size(); i++) {
+                measureChild(mMatchParentChildren.get(i), childWidthMeasureSpec, changedHeightMeasureSpec);
+                totalWidth += mMatchParentChildren.get(i).getMeasuredWidth();
+                int measuredHeight = mMatchParentChildren.get(i).getMeasuredHeight();
+                if (maxHeight < measuredHeight) {
+                    maxHeight = measuredHeight;
+                    changedHeightMeasureSpec = MeasureSpec.makeMeasureSpec(maxHeight, MeasureSpec.AT_MOST);
+                }
+            }
+        }
+        super.onMeasure(MeasureSpec.makeMeasureSpec(layoutWidth, MeasureSpec.EXACTLY), changedHeightMeasureSpec);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+
+        int horizontalOffset = getPaddingLeft();
+        int verticalOffset = getPaddingTop();
+        int childCount = getChildCount();
+        for (int i = 0; i < childCount; ++i) {
+            View child = getChildAt(i);
+            int childWidth = child.getMeasuredWidth();
+            int childHeight = child.getMeasuredHeight();
+            child.layout(horizontalOffset, verticalOffset, horizontalOffset + childWidth, verticalOffset + childHeight);
+            horizontalOffset += childWidth;
+        }
+    }
+}

--- a/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
@@ -59,7 +59,10 @@ public class CustomLayout extends ViewGroup {
             }
         }
         //Если осталось место или оно не ограничено, почему бы не показать matchParent
-        if ((totalWidth < layoutWidth) || widthMeasureSpec == MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)) {
+        boolean haveSpace = (totalWidth < layoutWidth)
+                || widthMeasureSpec == MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
+        //И у нас есть, чем его заполнять
+        if ((mMatchParentChildren.size() > 0) && haveSpace) {
             //В случае, если не знаем ширина родителя не остановленна,используем  вдвое увеличенную ширину не match_parent элементов
             layoutWidth = layoutWidth != 0 ? layoutWidth : totalWidth * 2;
             //Остаток разделям между оставшимися детьми

--- a/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/layouts/CustomLayout.java
@@ -37,9 +37,6 @@ public class CustomLayout extends ViewGroup {
         for (int i = 0; i < getChildCount(); ++i) {
             View child = getChildAt(i);
 
-            if (child == null) {
-                continue;
-            }
             if (child.getVisibility() == GONE) {
                 continue;
             }

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
 
-    <TextView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/content"
-        android:textSize="42sp"
-        android:gravity="center"
-        />
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-</FrameLayout>
+
+        <include layout="@layout/inner_test_1"/>
+        <include layout="@layout/inner_test_2"/>
+        <include layout="@layout/inner_test_3"/>
+        <include layout="@layout/inner_test_5"/>
+        <include layout="@layout/inner_test_6"/>
+        <include layout="@layout/inner_test_7"/>
+        <include layout="@layout/inner_test_8"/>
+        <include layout="@layout/inner_test_9"/>
+        <include layout="@layout/inner_test_10"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -12,6 +12,7 @@
         <include layout="@layout/inner_test_1"/>
         <include layout="@layout/inner_test_2"/>
         <include layout="@layout/inner_test_3"/>
+        <include layout="@layout/inner_test_33"/>
         <include layout="@layout/inner_test_5"/>
         <include layout="@layout/inner_test_6"/>
         <include layout="@layout/inner_test_7"/>

--- a/app/src/main/res/layout/inner_test_1.xml
+++ b/app/src/main/res/layout/inner_test_1.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="wrap_content LL and CL with expecly width for all" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="1000dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+
+        <TextView
+            android:layout_width="1000dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_10.xml
+++ b/app/src/main/res/layout/inner_test_10.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="LL and CL with child  margin"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        >
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_margin="8dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="8dp"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_2.xml
+++ b/app/src/main/res/layout/inner_test_2.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="match_parent LL and CL with expecly width for all" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="1000dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="1000dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_3.xml
+++ b/app/src/main/res/layout/inner_test_3.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="LL and CL with padding" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:paddingBottom="4dp"
+        android:paddingRight="3dp"
+        android:paddingTop="8dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp"
+        android:paddingBottom="4dp"
+        android:paddingRight="3dp"
+        android:paddingTop="8dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_33.xml
+++ b/app/src/main/res/layout/inner_test_33.xml
@@ -34,6 +34,12 @@
             android:background="@color/colorPrimary" />
 
         <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@android:color/white" />
+
+        <TextView
             android:layout_width="70dp"
             android:layout_height="match_parent"
             android:background="@color/colorPrimaryDark" />
@@ -73,6 +79,10 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/colorPrimary" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/white" />
 
         <TextView
             android:layout_width="70dp"

--- a/app/src/main/res/layout/inner_test_4.xml
+++ b/app/src/main/res/layout/inner_test_4.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Elements with margin in LL and CL" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_margin="8dp"
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_margin="48dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_margin="4dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_5.xml
+++ b/app/src/main/res/layout/inner_test_5.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="match_parent LL(third height=0 weight=1) and Cl((third match_paretn))" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_6.xml
+++ b/app/src/main/res/layout/inner_test_6.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="100dp"
+        android:text="CL inSV matchparent" />
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ru.yandex.yamblz.ui.layouts.CustomLayout
+            android:layout_width="match_parent"
+            android:layout_height="100dp">
+
+            <TextView
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:background="@color/gray" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorAccent" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimary" />
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimaryDark" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/d2m_font_default_description" />
+        </ru.yandex.yamblz.ui.layouts.CustomLayout>
+    </HorizontalScrollView>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="100dp"
+        android:text="CL inSV wrapcontent" />
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ru.yandex.yamblz.ui.layouts.CustomLayout
+            android:layout_width="wrap_content"
+            android:layout_height="100dp">
+
+            <TextView
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:background="@color/gray" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorAccent" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimary" />
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimaryDark" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/d2m_font_default_description" />
+        </ru.yandex.yamblz.ui.layouts.CustomLayout>
+    </HorizontalScrollView>
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="100dp"
+        android:text="CL inSV matchparent last1000" />
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ru.yandex.yamblz.ui.layouts.CustomLayout
+            android:layout_width="match_parent"
+            android:layout_height="100dp">
+
+            <TextView
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:background="@color/gray" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorAccent" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimary" />
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimaryDark" />
+
+            <TextView
+                android:layout_width="1000dp"
+                android:layout_height="match_parent"
+                android:background="@color/d2m_font_default_description" />
+        </ru.yandex.yamblz.ui.layouts.CustomLayout>
+    </HorizontalScrollView>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="100dp"
+        android:text="CL inSV wrapcontent last1000" />
+
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ru.yandex.yamblz.ui.layouts.CustomLayout
+            android:layout_width="wrap_content"
+            android:layout_height="100dp">
+
+            <TextView
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:background="@color/gray" />
+
+            <TextView
+                android:layout_width="100dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorAccent" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimary" />
+
+            <TextView
+                android:layout_width="70dp"
+                android:layout_height="match_parent"
+                android:background="@color/colorPrimaryDark" />
+
+            <TextView
+                android:layout_width="1000dp"
+                android:layout_height="match_parent"
+                android:background="@color/d2m_font_default_description" />
+        </ru.yandex.yamblz.ui.layouts.CustomLayout>
+    </HorizontalScrollView>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_7.xml
+++ b/app/src/main/res/layout/inner_test_7.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="match_parent LL(second and four areheight=0 weight=1) and Cl(second and four are match_paretn)" />
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_8.xml
+++ b/app/src/main/res/layout/inner_test_8.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="CustomLayout different hight test" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="120dp"
+            android:layout_height="wrap_content"
+            android:text="@string/content"
+            android:textSize="32sp"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content"
+            android:textSize="32sp"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/content"
+            android:textSize="32sp"
+            android:gravity="center"
+            />
+
+        <TextView
+            android:layout_width="120dp"
+            android:layout_height="wrap_content"
+            android:text="@string/content"
+            android:textSize="32sp"
+            android:gravity="center"
+            />
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/layout/inner_test_9.xml
+++ b/app/src/main/res/layout/inner_test_9.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="LL and CL with margin"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_margin="8dp"
+        >
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/black" />
+
+    <ru.yandex.yamblz.ui.layouts.CustomLayout
+        android:layout_width="wrap_content"
+        android:layout_height="100dp"
+        android:layout_margin="8dp">
+
+        <TextView
+            android:layout_width="10dp"
+            android:layout_height="match_parent"
+            android:background="@color/gray" />
+
+        <TextView
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="70dp"
+            android:layout_height="match_parent"
+            android:background="@color/colorPrimaryDark" />
+
+
+        <TextView
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@color/d2m_font_default_description" />
+
+    </ru.yandex.yamblz.ui.layouts.CustomLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:background="@color/black" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Yamblz</string>
+    <string name="app_name">Custom ViewGroup</string>
     <string name="content">Hello</string>
 </resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         compileSdk                   : 23,
         buildTools                   : '23.0.3',
 
-        androidGradlePlugin          : '2.2.0-alpha4',
+        androidGradlePlugin          : '2.2.0-alpha6',
         aptGradlePlugin              : '1.8',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         compileSdk                   : 23,
         buildTools                   : '23.0.3',
 
-        androidGradlePlugin          : '2.2.0-alpha6',
+        androidGradlePlugin          : '2.2.0-alpha7',
         aptGradlePlugin              : '1.8',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         compileSdk                   : 23,
         buildTools                   : '23.0.3',
 
-        androidGradlePlugin          : '2.2.0-alpha7',
+        androidGradlePlugin          : '2.2.0-beta1',
         aptGradlePlugin              : '1.8',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 22 14:49:54 MSK 2016
+#Tue Aug 09 20:47:38 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 30 20:17:48 ICT 2016
+#Fri Jul 22 14:49:54 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip


### PR DESCRIPTION
Запрошенное в задании поведение аналогично LinearLayout с layout_heigh=match_parent, искомый элемент match_parent в CustomLayout аналогичен элементу данного LL weight=n(у всех одно, если хотим несколько) и layout_width=0dp.

Рассмотрено большое количество различных случаев размещения CustomLayout и его сравнение с LL, в частности:
возможность  расположения нескольких элементов c width match_parent, расстояние делится поровну
отсутствие элементов с match_parent
расположения CustomLayout в ScrollView и HorizontalScrollView
установка margin и padding CustomLayout
различная высота вложенных View
и что-нибудь еще

Точно отсутствует:
margin у детей (интересно, как это происходит?)

![device-2016-07-27-072138](https://cloud.githubusercontent.com/assets/1605901/17163921/358c44ba-53cc-11e6-97bf-51f95dce0082.png)
![device-2016-07-27-072211](https://cloud.githubusercontent.com/assets/1605901/17163920/358b7abc-53cc-11e6-8cd2-1d60ebd0168b.png)
![device-2016-07-27-072220](https://cloud.githubusercontent.com/assets/1605901/17163922/358d72b8-53cc-11e6-8ac1-0bc51b9dc1ad.png)
![device-2016-07-27-072230](https://cloud.githubusercontent.com/assets/1605901/17163924/35900280-53cc-11e6-9648-39a3418dc2fa.png)
![device-2016-07-27-072240](https://cloud.githubusercontent.com/assets/1605901/17163923/358e0e12-53cc-11e6-81c8-5d7a3e05dbf6.png)
